### PR TITLE
more arguments added

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,16 +18,21 @@ rule
 
 ### Attribute Parameters
 
-- attribute :port, :kind_of => Integer
-- attribute :name, :kind_of => String, :name_attribute => true
-- attribute :direction, :kind_of => Symbol, :default => :in, :equal_to => [:in, :out]
-- attribute :protocol, :kind_of => Symbol, :default => :TCP, :equal_to => [:TCP]
-- attribute :firewall_action, :kind_of => Symbol, :default => :allow, :equal_to => [:allow, :deny]
+-attribute :name, :kind_of => String, :name_attribute => true
+-attribute :direction, :kind_of => Symbol, :default => :in, :equal_to => [:in, :out]
+-attribute :protocol, :kind_of => Symbol, :default => :TCP, :equal_to => [:TCP]
+-attribute :firewall_action, :kind_of => Symbol, :default => :allow, :equal_to => [:allow, :deny]
+-attribute :localport, :kind_of => String, :default => :Any
+-attribute :remoteport, :kind_of => String, :default => :Any
+-attribute :program, :kind_of => String, :default => :Any
+-attribute :remoteaddress, :kind_of => String, :default => :Any
+
 
 ### Examples
 
     windows_firewall_rule 'Apache' do
-          port 8080
-          protocol :TCP
-          firewall_action :allow
+        localport "8080"
+        protocol :TCP
+        firewall_action :allow
+		direction :in
     end

--- a/providers/rule.rb
+++ b/providers/rule.rb
@@ -15,8 +15,6 @@ action :open do
 		args['program'] = @new_resource.program
 		args['remoteip'] = @new_resource.remoteaddress
 		
-		
-		
 		cmdargs = args.map{|k,v| "#{k}=#{v}"}.join(' ')
 
     currentRule = shell_out("netsh advfirewall firewall show rule name=\"#{name}\"")

--- a/providers/rule.rb
+++ b/providers/rule.rb
@@ -10,7 +10,12 @@ action :open do
 		args['dir'] = @new_resource.direction
 		args['action'] = @new_resource.firewall_action
 		args['protocol'] = @new_resource.protocol
-		args['localport'] = @new_resource.port
+		args['localport'] = @new_resource.localport
+		args['remoteport'] = @new_resource.remoteport
+		args['program'] = @new_resource.program
+		args['remoteip'] = @new_resource.remoteaddress
+		
+		
 		
 		cmdargs = args.map{|k,v| "#{k}=#{v}"}.join(' ')
 

--- a/recipes/ApacheRule.rb
+++ b/recipes/ApacheRule.rb
@@ -1,0 +1,5 @@
+windows_firewall_rule 'Apache' do
+          port 8080
+          protocol :TCP
+          firewall_action :allow
+    end

--- a/recipes/ApacheRule.rb
+++ b/recipes/ApacheRule.rb
@@ -1,5 +1,5 @@
 windows_firewall_rule 'Apache' do
-          port 8080
+          port "8080"
           protocol :TCP
           firewall_action :allow
     end

--- a/resources/rule.rb
+++ b/resources/rule.rb
@@ -1,10 +1,16 @@
 actions :open
 
-attribute :port, :kind_of => Integer
+attribute :localport, :kind_of => String, :default => :Any
 attribute :name, :kind_of => String, :name_attribute => true
 attribute :direction, :kind_of => Symbol, :default => :in, :equal_to => [:in, :out]
 attribute :protocol, :kind_of => Symbol, :default => :TCP, :equal_to => [:TCP]
 attribute :firewall_action, :kind_of => Symbol, :default => :allow, :equal_to => [:allow, :deny]
+attribute :remoteport, :kind_of => String, :default => :Any
+attribute :program, :kind_of => String, :default => :Any
+attribute :remoteaddress, :kind_of => String, :default => :Any
+
+
+
 
 def initialize(*args)
   super


### PR DESCRIPTION
I added more arguments so I could create more specific Windows Firewall rules.   I still need to figure out how to make it work when the protocol is ICMPv4.   I can add it as an option and all, but the netsh command has different required options when you have ICMPv4 as the protocol.   

This is the first one I've ever messed with, so I'm just learning.   Maybe you can make use of some of the options I added.