### PR TITLE
Add support for running on localized versions of Windows

### DIFF
--- a/resources/rule.rb
+++ b/resources/rule.rb
@@ -30,7 +30,7 @@ property :service, String
 property :interfacetype, Symbol, default: :any, equal_to: [:any, :wireless, :lan, :ras]
 
 load_current_value do
-  current_rule = shell_out("netsh advfirewall firewall show rule name=\"#{rule_name}\"")
+  current_rule = shell_out("chcp 437 >null 2>&1 && cmd.exe /c netsh advfirewall firewall show rule name=\"#{rule_name}\"")
 
   current_value_does_not_exist! if current_rule.stdout.strip == 'No rules match the specified criteria.'
 end


### PR DESCRIPTION
Signed-off-by: Anton Kvashenkin <anton.jugatsu@gmail.com>

### Description

Add support for running `windows_firewall_rule` resource on all flavors of localized versions of Windows.

### Check List

- [x] Tested on Windows 10 Russian with 13.9 chef-client
- [x] Tested on Windows 10 English with 13.9 chef-client