### PR TITLE
Fully support multi-port local_port and remote_port

### DIFF
--- a/kitchen.appveyor.yml
+++ b/kitchen.appveyor.yml
@@ -15,7 +15,8 @@ provisioner:
   name: chef_zero
   deprecations_as_errors: true
   product_name: chef
-  channel: current
+  channel: stable
+  version: 14.6
 
 platforms:
   - name: windows-2012R2

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -27,6 +27,8 @@ platforms:
     driver_config:
       gui: true
       box: tas50/windows_2012r2
+    provisioner:
+      require_chef_omnibus: 14.6
   - name: windows_2016-chef13
     driver_config:
       gui: true
@@ -38,6 +40,8 @@ platforms:
     driver_config:
       gui: true
       box: tas50/windows_2016
+    provisioner:
+      require_chef_omnibus: 14.6
 suites:
   - name: default
     run_list:

--- a/resources/rule.rb
+++ b/resources/rule.rb
@@ -23,6 +23,9 @@
 # limitations under the License.
 #
 
+chef_version_for_provides '< 14.7' if respond_to?(:chef_version_for_provides)
+resource_name :widows_firewall
+
 require 'chef/json_compat'
 
 property :rule_name, String, name_property: true

--- a/resources/rule.rb
+++ b/resources/rule.rb
@@ -29,10 +29,10 @@ property :rule_name, String, name_property: true
 property :description, String, default: 'Firewall rule'
 property :local_address, String
 property :local_port, [String, Integer, Array],
-         coerce: proc { |d| d.is_a?(String) ? d.split(/\s*,\s*/).sort : Array(d).sort }
+         coerce: proc { |d| d.is_a?(String) ? d.split(/\s*,\s*/).sort : Array(d).sort.map(&:to_s) }
 property :remote_address, String
 property :remote_port, [String, Integer, Array],
-         coerce: proc { |d| d.is_a?(String) ? d.split(/\s*,\s*/).sort : Array(d).sort }
+         coerce: proc { |d| d.is_a?(String) ? d.split(/\s*,\s*/).sort : Array(d).sort.map(&:to_s) }
 property :direction, [Symbol, String], default: :inbound, equal_to: [:inbound, :outbound],
                                        coerce: proc { |d| d.is_a?(String) ? d.downcase.to_sym : d }
 property :protocol, String, default: 'TCP'

--- a/resources/rule.rb
+++ b/resources/rule.rb
@@ -24,7 +24,7 @@
 #
 
 chef_version_for_provides '< 14.7' if respond_to?(:chef_version_for_provides)
-resource_name :widows_firewall
+resource_name :windows_firewall_rule
 
 require 'chef/json_compat'
 

--- a/test/cookbooks/test/recipes/default.rb
+++ b/test/cookbooks/test/recipes/default.rb
@@ -3,11 +3,30 @@
 # Recipe:: default
 # tests the firewall resource
 
+# test localport as a comma sep list w/o spacing
 windows_firewall_rule 'Apache' do
   local_port '8080,80'
   protocol 'TCP'
   firewall_action :allow
-  program 'c:\program files\test.exe'
+  program 'c:\program files\apache.exe'
+  local_address '192.168.1.1'
+end
+
+# test localport as a comma sep list with spacing
+windows_firewall_rule 'App1' do
+  local_port '8080, 80'
+  protocol 'TCP'
+  firewall_action :allow
+  program 'c:\program files\app2.exe'
+  local_address '192.168.1.1'
+end
+
+# test local_port as an array
+windows_firewall_rule 'App2' do
+  local_port [8080, 80]
+  protocol 'TCP'
+  firewall_action :allow
+  program 'c:\program files\app2.exe'
   local_address '192.168.1.1'
 end
 


### PR DESCRIPTION
Powershell returns an array if there's more than one port. Allow Array and properly sort the arrays. Also work around a bug where an array in PS gets turned into a Hash with the count and value keys with ConvertTo-Json. I linked to the stackoverflow that discussed the issue within the code so the reason isn't lost on future readers.

Signed-off-by: Tim Smith <tsmith@chef.io>